### PR TITLE
Rename Service.base_url to url for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ global:
 
 services:
   - name: user-service
-    base_url: http://user-service:8081
+    url: http://user-service:8081
     routes:
       - path: /users
 
   - name: transaction-service
-    base_url: http://transaction-service:8082
+    url: http://transaction-service:8082
     routes:
       - path: /v1.0/transaction
 ```
@@ -87,7 +87,7 @@ See `config/entriq.example.yaml` for a complete configuration reference with all
 
 **Services**:
 - `name`: Service identifier
-- `base_url`: Backend service URL
+- `url`: Backend service URL
 - `timeout`: Service-specific timeout (optional)
 - `retry`: Service-specific retry policy (optional)
 - `routes`: List of routing rules

--- a/config/entriq.example.yaml
+++ b/config/entriq.example.yaml
@@ -68,7 +68,7 @@ headers:
 services:
   # Example user service
   - name: user-service
-    base_url: http://user-service:8081
+    url: http://user-service:8081
     timeout: 10s                         # Service-level timeout (overrides gateway default)
 
     # Service-level retry policy (overrides gateway default)
@@ -100,7 +100,7 @@ services:
 
   # Example transaction service
   - name: transaction-service
-    base_url: http://transaction-service:8082
+    url: http://transaction-service:8082
     timeout: 15s
     routes:
       - path: /v1.0/transaction
@@ -109,7 +109,7 @@ services:
 
   # Example authentication service
   - name: auth-service
-    base_url: http://auth-service:8083
+    url: http://auth-service:8083
     timeout: 5s
     routes:
       # Login endpoint - no auth required

--- a/config/entriq.yaml
+++ b/config/entriq.yaml
@@ -13,7 +13,7 @@ global:
 services:
 
   - name: platform-core
-    base_url: http://localhost:8040
+    url: http://localhost:8040
     timeout: 10s
     routes:
       - path: /v1.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,7 +93,7 @@ type HeaderSettings struct {
 // Service represents a backend microservice
 type Service struct {
 	Name    string       `yaml:"name"`
-	BaseURL string       `yaml:"base_url"`
+	URL     string       `yaml:"url"`
 	Timeout time.Duration `yaml:"timeout,omitempty"`
 	Retry   *RetryPolicy `yaml:"retry,omitempty"`
 	Routes  []Route      `yaml:"routes"`
@@ -177,8 +177,8 @@ func (c *GatewayConfig) Validate() error {
 		}
 		serviceNames[service.Name] = true
 
-		if service.BaseURL == "" {
-			return fmt.Errorf("services[%d] (%s): base_url is required", i, service.Name)
+		if service.URL == "" {
+			return fmt.Errorf("services[%d] (%s): url is required", i, service.Name)
 		}
 
 		if len(service.Routes) == 0 {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -120,7 +120,7 @@ func (g *Gateway) ProxyHandler() gin.HandlerFunc {
 		g.headerManipulator.Apply(c.Request, routeHeaders, clientIP)
 
 		// Log request start
-		requestID := g.proxyLogger.LogRequest(c.Request, match.Service.Name, match.Service.BaseURL)
+		requestID := g.proxyLogger.LogRequest(c.Request, match.Service.Name, match.Service.URL)
 
 		// Wrap response writer to capture status code
 		wrappedWriter := g.proxyLogger.WrapResponseWriter(c.Writer)
@@ -136,7 +136,7 @@ func (g *Gateway) ProxyHandler() gin.HandlerFunc {
 		latency := time.Since(startTime)
 
 		// Log response
-		g.proxyLogger.LogResponse(requestID, match.Service.Name, match.Service.BaseURL, wrappedWriter.StatusCode, latency, nil)
+		g.proxyLogger.LogResponse(requestID, match.Service.Name, match.Service.URL, wrappedWriter.StatusCode, latency, nil)
 	}
 }
 

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -29,7 +29,7 @@ func NewProxyHandler(match *RouteMatch, cfg *config.GatewayConfig, transport *ht
 // ServeHTTP implements the http.Handler interface
 func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Parse backend URL
-	backend, err := url.Parse(p.match.Service.BaseURL)
+	backend, err := url.Parse(p.match.Service.URL)
 	if err != nil {
 		http.Error(w, "Invalid backend URL", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary
- Renames `base_url` to `url` on the `Service` struct to be consistent with `ForwardAuth` and `RouteForwardAuth` which already use `url`
- Updates all internal references in `gateway.go` and `proxy.go`
- Updates `entriq.yaml`, `entriq.example.yaml`, and README

Closes #17

## Breaking Change
Existing `entriq.yaml` files using `base_url` must be updated to `url`.

## Test plan
- [x] Gateway starts with `url` field in service config
- [x] Missing `url` produces error: `services[0] (name): url is required`
- [x] Old `base_url` field is silently ignored (user gets the required error, not a crash)