### PR TITLE
Rename Route.method to methods

### DIFF
--- a/config/entriq.example.yaml
+++ b/config/entriq.example.yaml
@@ -81,14 +81,14 @@ services:
     routes:
       # Prefix match: /users, /users/123, /users/123/profile all match
       - path: /users
-        method: ["GET", "POST", "PUT", "DELETE"]
+        methods: ["GET", "POST", "PUT", "DELETE"]
         match_type: prefix
         strip_path: false                # If true, "/users/123" becomes "/123" when forwarding
         # Forward auth inherits from global setting (enabled: true)
 
       # Exact match: only /users/bulk matches
       - path: /users/bulk
-        method: ["POST"]
+        methods: ["POST"]
         match_type: exact
         timeout: 60s                     # Route-level timeout (overrides service and gateway)
         headers:
@@ -114,24 +114,24 @@ services:
     routes:
       # Login endpoint - no auth required
       - path: /auth/login
-        method: ["POST"]
+        methods: ["POST"]
         match_type: exact
         forward_auth:
           enabled: false                 # Public endpoint, no auth needed
 
       # Logout endpoint - auth required (inherits from global)
       - path: /auth/logout
-        method: ["POST"]
+        methods: ["POST"]
         match_type: exact
 
       # Token refresh endpoint - auth required (inherits from global)
       - path: /auth/refresh
-        method: ["POST"]
+        methods: ["POST"]
         match_type: exact
 
       # Verify endpoint - this is the actual forward auth endpoint
       - path: /auth/verify
-        method: ["GET", "POST"]
+        methods: ["GET", "POST"]
         match_type: exact
         forward_auth:
           enabled: false                 # Don't auth the auth endpoint itself!

--- a/config/entriq.yaml
+++ b/config/entriq.yaml
@@ -17,7 +17,7 @@ services:
     timeout: 10s
     routes:
       - path: /v1.0
-        method: ["GET", "POST"]
+        methods: ["GET", "POST"]
         match_type: prefix
         strip_path: false
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,7 +102,7 @@ type Service struct {
 // Route represents a routing rule
 type Route struct {
 	Path        string             `yaml:"path"`
-	Method      []string           `yaml:"method,omitempty"`
+	Methods     []string           `yaml:"methods,omitempty"`
 	MatchType   string             `yaml:"match_type"` // "prefix" or "exact"
 	StripPath   bool               `yaml:"strip_path"`
 	Timeout     time.Duration      `yaml:"timeout,omitempty"`
@@ -288,7 +288,7 @@ func (r *Route) Validate() error {
 		"PATCH": true, "HEAD": true, "OPTIONS": true,
 	}
 
-	for _, method := range r.Method {
+	for _, method := range r.Methods {
 		if !validMethods[method] {
 			return fmt.Errorf("invalid HTTP method: %s", method)
 		}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -136,8 +136,8 @@ func MergeDefaults(cfg *GatewayConfig) {
 			if route.MatchType == "" {
 				route.MatchType = DefaultRouteMatchType
 			}
-			if len(route.Method) == 0 {
-				route.Method = DefaultRouteAllowedMethods
+			if len(route.Methods) == 0 {
+				route.Methods = DefaultRouteAllowedMethods
 			}
 		}
 	}

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -53,9 +53,9 @@ func NewRouter(cfg *config.GatewayConfig) *Router {
 			}
 
 			if route.MatchType == "exact" {
-				router.addExactRoute(route.Path, route.Method, match)
+				router.addExactRoute(route.Path, route.Methods, match)
 			} else {
-				router.addPrefixRoute(route.Path, route.Method, match)
+				router.addPrefixRoute(route.Path, route.Methods, match)
 			}
 		}
 	}
@@ -116,7 +116,7 @@ func (r *Router) Match(method, path string) (*RouteMatch, error) {
 	for _, pr := range r.prefixRoutes {
 		if strings.HasPrefix(path, pr.path) {
 			// Check if method matches
-			if r.methodMatches(method, pr.match.Route.Method) {
+			if r.methodMatches(method, pr.match.Route.Methods) {
 				return pr.match, nil
 			}
 		}
@@ -162,7 +162,7 @@ func (r *Router) DebugRoutes() string {
 
 	sb.WriteString("\nPrefix Routes:\n")
 	for _, pr := range r.prefixRoutes {
-		for _, method := range pr.match.Route.Method {
+		for _, method := range pr.match.Route.Methods {
 			sb.WriteString(fmt.Sprintf("  %s %s (prefix)\n", method, pr.path))
 		}
 	}


### PR DESCRIPTION
## Summary
- Renames `method` to `methods` (plural) on the `Route` struct — the field accepts a list so plural is semantically correct
- Updates all references in `config.go`, `loader.go`, and `router.go`
- Updates `entriq.yaml` and `entriq.example.yaml`

Closes #22

## Breaking Change
Existing config files using `method:` on routes must be updated to `methods:`.

## Test plan
- [x] Routes with `methods: ["GET", "POST"]` match correctly
- [x] Routes with no `methods` field get all methods by default
- [x] Old `method:` field is silently ignored (results in all-methods default)