### PR TITLE
Fix HIGH: implement proper readiness check on /probes/ready

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -19,8 +19,11 @@ func Routes(Router *gin.Engine, gw *gateway.Gateway) {
 		})
 
 		Routes_Probes.GET("/ready", func(c *gin.Context) {
-			// TODO: Add gateway health checks here if needed
-			// For now, just return 200 OK
+			cfg := gw.GetConfig()
+			if cfg == nil || len(cfg.Services) == 0 {
+				c.AbortWithStatus(503)
+				return
+			}
 			c.AbortWithStatus(200)
 		})
 	}


### PR DESCRIPTION
## Summary
- `/probes/ready` now returns `503` when the gateway config is nil or has no services configured
- Returns `200` when at least one service is configured and the gateway is ready
- `/probes/live` unchanged — always returns `200`
- No body in responses — kubelet only needs the status code

Closes #6

## Test plan
- [x] `/probes/ready` returns 200 when services are configured
- [x] `/probes/ready` returns 503 when no services are configured
- [x] `/probes/live` always returns 200